### PR TITLE
QC-13284: Updated the repo's configuration to allow Github packages generation

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+registry = https://registry.npmjs.org/
+@qumu:registry=https://npm.pkg.github.com/qumu
+save-exact=true

--- a/package.json
+++ b/package.json
@@ -33,5 +33,8 @@
   "scripts": {
     "build": "npx microbundle --no-sourcemap --no-pkg-main --no-compress -f umd -o dist/autosize.js && npx microbundle --no-sourcemap -f esm,umd",
     "dev": "npx microbundle --no-sourcemap --no-pkg-main --no-compress -f umd -o dist/autosize.js watch"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
   }
 }


### PR DESCRIPTION
If we are to generate the packages in the `@qumu` registry, we need to update some files. 

This PR makes sure that the repo is ready for it